### PR TITLE
FIX: mod-consortia-keycloak version

### DIFF
--- a/Poppy/app-platform-complete.json
+++ b/Poppy/app-platform-complete.json
@@ -18,10 +18,10 @@
       "url": "https://mdr-folio-eis-us-east-1-dev.s3.amazonaws.com/mod-organizations-1.8.0"
     },
     {
-      "id": "mod-consortia-keycloak-1.1.0",
+      "id": "mod-consortia-keycloak-1.0.0",
       "name": "mod-consortia-keycloak",
-      "version": "1.1.0",
-      "url": "https://mdr-folio-eis-us-east-1-dev.s3.amazonaws.com/eureka/mod-consortia-keycloak-1.1.0"
+      "version": "1.0.0",
+      "url": "https://mdr-folio-eis-us-east-1-dev.s3.amazonaws.com/eureka/mod-consortia-keycloak-1.0.0"
     },
     {
       "id": "mod-organizations-storage-4.6.0",


### PR DESCRIPTION
## Purpose

The actual version of mod-consortia-keycloak is 1.0.0

## Approach

- update module descriptor version

