### PR TITLE
APPDESCRIP-6 Add ui-authz-policies, ui-authz-roles to app-platform-minimal

### DIFF
--- a/Poppy/app-platform-minimal.json
+++ b/Poppy/app-platform-minimal.json
@@ -109,6 +109,18 @@
       "name": "folio_stripes-smart-components",
       "version": "9.0.2",
       "url": "https://folio-registry.dev.folio.org/_/proxy/modules/folio_stripes-smart-components-9.0.2"
+    },
+    {
+      "id": "folio_authorization-policies-1.2.1",
+      "name": "folio_authorization-policies",
+      "version": "1.2.1",
+      "url": "https://folio-registry.dev.folio.org/_/proxy/modules/folio_authorization-policies-1.2.1"
+    },
+    {
+      "id": "folio_authorization-roles-1.3.0",
+      "name": "folio_authorization-roles",
+      "version": "1.3.0",
+      "url": "https://folio-registry.dev.folio.org/_/proxy/modules/folio_authorization-roles-1.3.0"
     }
   ]
 }

--- a/Poppy/install.json
+++ b/Poppy/install.json
@@ -506,5 +506,13 @@
   {
     "id": "folio_consortia-settings-1.0.2",
     "action": "enable"
+  },
+  {
+    "id": "folio_authorization-policies-1.2.1",
+    "action": "enable"
+  },
+  {
+    "id": "folio_authorization-roles-1.3.0",
+    "action": "enable"
   }
 ]


### PR DESCRIPTION
Include `ui-authorization-policies` and `ui-authorization-roles` in `app-platform-minimal` because they include module-descriptors with user-facing permissions.

Refs [APPDESCRIP-6](https://folio-org.atlassian.net/browse/APPDESCRIP-6)
