### PR TITLE
Update app-edge-locate.json for Q (Part 1)

### DIFF
--- a/Quesnelia/app-edge-locate.json
+++ b/Quesnelia/app-edge-locate.json
@@ -1,7 +1,7 @@
 {
-  "id": "app-edge-locate-0.0.8",
+  "id": "app-edge-locate-0.0.9",
   "name": "app-edge-locate",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "platform": "complete",
   "dependencies": [
     {
@@ -11,22 +11,10 @@
   ],
   "modules": [
     {
-      "id": "edge-inventory-1.4.0",
+      "id": "edge-inventory-1.5.2",
       "name": "edge-inventory",
-      "version": "1.4.0",
-      "url": "https://mdr-folio-eis-us-east-1-dev.s3.amazonaws.com/edge-inventory-1.4.0"
-    },
-    {
-      "id": "edge-users-1.2.0",
-      "name": "edge-users",
-      "version": "1.2.0",
-      "url": "https://mdr-folio-eis-us-east-1-dev.s3.amazonaws.com/edge-users-1.2.0"
-    },
-    {
-      "id": "edge-erm-1.0.0",
-      "name": "edge-erm",
-      "version": "1.0.0",
-      "url": "https://mdr-folio-eis-us-east-1-dev.s3.amazonaws.com/edge-erm-1.0.0"
+      "version": "1.5.2",
+      "url": "https://mdr-folio-eis-us-east-1-dev.s3.amazonaws.com/edge-inventory-1.5.2"
     }
   ]
 }


### PR DESCRIPTION
## Purpose

Rolling out new edge modules for locate.

Only edge-inventory is ready and supports FIPS/TLS

edge-erm and edge-users will be added when the work is done to make them support FIPS/TLS. That will be part 2

app-edge-locate-0.0.8 --> app-edge-locate-0.0.9
edge-inventory-1.4.0   --> edge-inventory-1.5.2
