### PR TITLE
Update app-edge-locate.json for new locate release 2024.9.1

### DIFF
--- a/Quesnelia/app-edge-locate.json
+++ b/Quesnelia/app-edge-locate.json
@@ -1,7 +1,7 @@
 {
-  "id": "app-edge-locate-0.0.10",
+  "id": "app-edge-locate-0.0.11",
   "name": "app-edge-locate",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "platform": "complete",
   "dependencies": [
     {
@@ -11,16 +11,16 @@
   ],
   "modules": [
     {
-      "id": "edge-inventory-1.5.2",
+      "id": "edge-inventory-1.6.1",
       "name": "edge-inventory",
-      "version": "1.5.2",
-      "url": "https://mdr-folio-eis-us-east-1-dev.s3.amazonaws.com/edge-inventory-1.5.2"
+      "version": "1.6.1",
+      "url": "https://mdr-folio-eis-us-east-1-dev.s3.amazonaws.com/edge-inventory-1.6.1"
     },
     {
-      "id": "edge-users-1.4.0",
+      "id": "edge-users-1.5.0",
       "name": "edge-users",
-      "version": "1.4.0",
-      "url": "https://mdr-folio-eis-us-east-1-dev.s3.amazonaws.com/edge-users-1.4.0"
+      "version": "1.5.0",
+      "url": "https://mdr-folio-eis-us-east-1-dev.s3.amazonaws.com/edge-users-1.5.0"
     }
   ]
 }


### PR DESCRIPTION
[US1309901](https://rally1.rallydev.com/#/?detail=/userstory/809721636339&fdp=true): (P3) Support LOC Release for September - w/o 9/23 (need by 9/23/24)

I also updated the id and version number. is that correct?

