### PR TITLE
APPDESCRIP-40: Q: Update Keycloak Modules in Application Descriptors

### DIFF
--- a/Quesnelia/app-consortia.json
+++ b/Quesnelia/app-consortia.json
@@ -12,10 +12,10 @@
   ],
   "modules": [
     {
-      "id": "mod-consortia-keycloak-1.5.1",
+      "id": "mod-consortia-keycloak-1.5.2",
       "name": "mod-consortia-keycloak",
-      "version": "1.5.1",
-      "url": "https://mdr-folio-eis-us-east-1-dev.s3.amazonaws.com/mod-consortia-keycloak-1.5.1"
+      "version": "1.5.2",
+      "url": "https://mdr-folio-eis-us-east-1-dev.s3.amazonaws.com/mod-consortia-keycloak-1.5.2"
     }
   ],
   "uiModules": [

--- a/Quesnelia/app-platform-minimal.json
+++ b/Quesnelia/app-platform-minimal.json
@@ -43,22 +43,22 @@
       "url": "https://mdr-folio-eis-us-east-1-dev.s3.amazonaws.com/mod-password-validator-3.2.1"
     },
     {
-      "id": "mod-login-keycloak-1.5.0",
+      "id": "mod-login-keycloak-1.5.1",
       "name": "mod-login-keycloak",
-      "version": "1.5.0",
-      "url": "https://mdr-folio-eis-us-east-1-dev.s3.amazonaws.com/mod-login-keycloak-1.5.0"
+      "version": "1.5.1",
+      "url": "https://mdr-folio-eis-us-east-1-dev.s3.amazonaws.com/mod-login-keycloak-1.5.1"
     },
     {
-      "id": "mod-users-keycloak-1.6.0",
+      "id": "mod-users-keycloak-1.6.1",
       "name": "mod-users-keycloak",
-      "version": "1.6.0",
-      "url": "https://mdr-folio-eis-us-east-1-dev.s3.amazonaws.com/mod-users-keycloak-1.6.0"
+      "version": "1.6.1",
+      "url": "https://mdr-folio-eis-us-east-1-dev.s3.amazonaws.com/mod-users-keycloak-1.6.1"
     },
     {
-      "id": "mod-roles-keycloak-1.4.6",
+      "id": "mod-roles-keycloak-1.4.7",
       "name": "mod-roles-keycloak",
-      "version": "1.4.6",
-      "url": "https://mdr-folio-eis-us-east-1-dev.s3.amazonaws.com/mod-roles-keycloak-1.4.6"
+      "version": "1.4.7",
+      "url": "https://mdr-folio-eis-us-east-1-dev.s3.amazonaws.com/mod-roles-keycloak-1.4.7"
     },
     {
       "id": "mod-notes-5.2.0",
@@ -67,10 +67,10 @@
       "url": "https://mdr-folio-eis-us-east-1-dev.s3.amazonaws.com/mod-notes-5.2.0"
     },
     {
-      "id": "mod-scheduler-1.3.0",
+      "id": "mod-scheduler-1.3.1",
       "name": "mod-scheduler",
-      "version": "1.3.0",
-      "url": "https://mdr-folio-eis-us-east-1-dev.s3.amazonaws.com/mod-scheduler-1.3.0"
+      "version": "1.3.1",
+      "url": "https://mdr-folio-eis-us-east-1-dev.s3.amazonaws.com/mod-scheduler-1.3.1"
     },
     {
       "id": "mod-settings-1.0.3",

--- a/Quesnelia/install.json
+++ b/Quesnelia/install.json
@@ -552,23 +552,23 @@
     "action": "enable"
   },
   {
-    "id": "mod-roles-keycloak-1.4.6",
+    "id": "mod-roles-keycloak-1.4.7",
     "action": "enable"
   },
   {
-    "id": "mod-users-keycloak-1.6.0",
+    "id": "mod-users-keycloak-1.6.1",
     "action": "enable"
   },
   {
-    "id": "mod-login-keycloak-1.5.0",
+    "id": "mod-login-keycloak-1.5.1",
     "action": "enable"
   },
   {
-    "id": "mod-consortia-keycloak-1.5.1",
+    "id": "mod-consortia-keycloak-1.5.2",
     "action": "enable"
   },
   {
-    "id": "mod-scheduler-1.3.0",
+    "id": "mod-scheduler-1.3.1",
     "action": "enable"
   }
 ]


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/APPDESCRIP-40

Keycloak modules got security fixes for Quesnelia:

https://github.com/folio-org/mod-consortia-keycloak/releases/tag/v1.5.2

https://github.com/folio-org/mod-login-keycloak/releases/tag/v1.5.1

https://github.com/folio-org/mod-users-keycloak/releases/tag/v1.6.1

https://github.com/folio-org/mod-roles-keycloak/releases/tag/v1.4.7

https://github.com/folio-org/mod-scheduler/releases/tag/v1.3.1

Upgrade https://github.com/folio-org/application-descriptors/tree/master/Quesnelia to the fixed versions.

## Purpose
Fix security issues of keycloak modules in Quesnelia.

## Approach
Bump the patch version in the application descriptors.

## TODOS and Open Questions
- [x] Check logging

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.